### PR TITLE
WW1 Coalition Update

### DIFF
--- a/AutoUpdater/MainWindow.xaml.cs
+++ b/AutoUpdater/MainWindow.xaml.cs
@@ -101,7 +101,7 @@ namespace AutoUpdater
         private async Task<Uri> GetPathToLatestVersion()
         {
             Status.Content = "Finding Latest IL2-SRS Version";
-            var githubClient = new GitHubClient(new ProductHeaderValue(GITHUB_USER_AGENT, "1.0.1.4"));
+            var githubClient = new GitHubClient(new ProductHeaderValue(GITHUB_USER_AGENT, "1.0.1.5"));
 
             var releases = await githubClient.Repository.Release.GetAll(GITHUB_USERNAME, GITHUB_REPOSITORY);
 

--- a/AutoUpdater/MainWindow.xaml.cs
+++ b/AutoUpdater/MainWindow.xaml.cs
@@ -101,7 +101,7 @@ namespace AutoUpdater
         private async Task<Uri> GetPathToLatestVersion()
         {
             Status.Content = "Finding Latest IL2-SRS Version";
-            var githubClient = new GitHubClient(new ProductHeaderValue(GITHUB_USER_AGENT, "1.0.1.3"));
+            var githubClient = new GitHubClient(new ProductHeaderValue(GITHUB_USER_AGENT, "1.0.1.4"));
 
             var releases = await githubClient.Repository.Release.GetAll(GITHUB_USERNAME, GITHUB_REPOSITORY);
 

--- a/AutoUpdater/Properties/AssemblyInfo.cs
+++ b/AutoUpdater/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.4")]
-[assembly: AssemblyFileVersion("1.0.1.4")]
+[assembly: AssemblyVersion("1.0.1.5")]
+[assembly: AssemblyFileVersion("1.0.1.5")]

--- a/AutoUpdater/Properties/AssemblyInfo.cs
+++ b/AutoUpdater/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.3")]
-[assembly: AssemblyFileVersion("1.0.1.3")]
+[assembly: AssemblyVersion("1.0.1.4")]
+[assembly: AssemblyFileVersion("1.0.1.4")]

--- a/AutoUpdater/Properties/app.manifest
+++ b/AutoUpdater/Properties/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.1.3" name="MyApplication.app" />
+  <assemblyIdentity version="1.0.1.4" name="MyApplication.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/AutoUpdater/Properties/app.manifest
+++ b/AutoUpdater/Properties/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.1.4" name="MyApplication.app" />
+  <assemblyIdentity version="1.0.1.5" name="MyApplication.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/IL2-SR-Client/Network/IL2/IL2RadioSyncHandler.cs
+++ b/IL2-SR-Client/Network/IL2/IL2RadioSyncHandler.cs
@@ -157,6 +157,12 @@ So if someone on Server has ParentID!=-1 but ParentID=12345 - this means that in
                     // playerRadioInfo.coalition = controlDataMessage.Coalition;
                     Logger.Info($"Ignore Coalition Update for Spectator");
                 }
+                else if (controlDataMessage.Coalition > 2)
+                {
+                    // Modifying WW1 coalitions to just behave as their WW2 counterparts
+                    playerRadioInfo.vehicleId = controlDataMessage.ParentVehicleClientID;
+                    playerRadioInfo.coalition = (short)(controlDataMessage.Coalition - 2);
+                }
                 else
                 {
                     playerRadioInfo.vehicleId = controlDataMessage.ParentVehicleClientID;

--- a/IL2-SR-Client/Properties/AssemblyInfo.cs
+++ b/IL2-SR-Client/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.4")]
-[assembly: AssemblyFileVersion("1.0.1.4")]
+[assembly: AssemblyVersion("1.0.1.5")]
+[assembly: AssemblyFileVersion("1.0.1.5")]

--- a/IL2-SR-Client/Properties/AssemblyInfo.cs
+++ b/IL2-SR-Client/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.3")]
-[assembly: AssemblyFileVersion("1.0.1.3")]
+[assembly: AssemblyVersion("1.0.1.4")]
+[assembly: AssemblyFileVersion("1.0.1.4")]

--- a/IL2-SR-Client/Properties/app.manifest
+++ b/IL2-SR-Client/Properties/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.1.3" name="MyApplication.app" />
+  <assemblyIdentity version="1.0.1.4" name="MyApplication.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/IL2-SR-Client/Properties/app.manifest
+++ b/IL2-SR-Client/Properties/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.1.4" name="MyApplication.app" />
+  <assemblyIdentity version="1.0.1.5" name="MyApplication.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/IL2-SR-Client/UI/ClientWindow/ClientList/ClientListWindow.xaml
+++ b/IL2-SR-Client/UI/ClientWindow/ClientList/ClientListWindow.xaml
@@ -5,9 +5,11 @@
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       Title="Connected Clients"
+                      MinWidth="300"
+                            MinHeight="390"
                       Width="300"
                       Height="390"
-                      ResizeMode="NoResize"
+                      ResizeMode="CanResizeWithGrip"
                       xmlns:clients="clr-namespace:Ciribob.IL2.SimpleRadio.Standalone.Client.UI.ClientWindow.ClientList"
                      >
     <ListBox Name="ClientList" HorizontalContentAlignment="Stretch" Padding="5" >

--- a/IL2-SR-Client/UI/ClientWindow/ClientList/ClientListWindow.xaml.cs
+++ b/IL2-SR-Client/UI/ClientWindow/ClientList/ClientListWindow.xaml.cs
@@ -1,8 +1,10 @@
 ﻿using MahApps.Metro.Controls;
 using NLog;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows.Threading;
 using Ciribob.IL2.SimpleRadio.Standalone.Client.Singletons;
 using Ciribob.IL2.SimpleRadio.Standalone.Common;
@@ -33,6 +35,11 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.UI.ClientWindow.ClientList
         private void UpdateList()
         {
             _clientList.Clear();
+
+            //first create temporary list to sort
+            var tempList = new List<ClientListModel>();
+
+
             foreach (var srClient in ConnectedClientsSingleton.Instance.Values)
             {
                 var client = new ClientListModel()
@@ -56,7 +63,13 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.UI.ClientWindow.ClientList
                     client.Channel = srClient.GameState.radios[1].Channel + "";
                 }
 
-                _clientList.Add(client);
+                tempList.Add(client);
+            }
+
+            foreach (var clientListModel in tempList.OrderByDescending(model => model.Coalition)
+                .ThenBy(model => model.Name.ToLower()).ToList())
+            {
+                _clientList.Add(clientListModel);
             }
         }
 

--- a/IL2-SR-Common/Network/UpdaterChecker.cs
+++ b/IL2-SR-Common/Network/UpdaterChecker.cs
@@ -21,7 +21,7 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Common
 
         public static readonly string MINIMUM_PROTOCOL_VERSION = "1.0.0.0";
 
-        public static readonly string VERSION = "1.0.1.4";
+        public static readonly string VERSION = "1.0.1.5";
 
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 

--- a/IL2-SR-Common/Network/UpdaterChecker.cs
+++ b/IL2-SR-Common/Network/UpdaterChecker.cs
@@ -21,7 +21,7 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Common
 
         public static readonly string MINIMUM_PROTOCOL_VERSION = "1.0.0.0";
 
-        public static readonly string VERSION = "1.0.1.3";
+        public static readonly string VERSION = "1.0.1.4";
 
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 

--- a/IL2-SR-Common/Properties/AssemblyInfo.cs
+++ b/IL2-SR-Common/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.4")]
-[assembly: AssemblyFileVersion("1.0.1.4")]
+[assembly: AssemblyVersion("1.0.1.5")]
+[assembly: AssemblyFileVersion("1.0.1.5")]

--- a/IL2-SR-Common/Properties/AssemblyInfo.cs
+++ b/IL2-SR-Common/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.3")]
-[assembly: AssemblyFileVersion("1.0.1.3")]
+[assembly: AssemblyVersion("1.0.1.4")]
+[assembly: AssemblyFileVersion("1.0.1.4")]

--- a/IL2-SR-CommonTests/Properties/AssemblyInfo.cs
+++ b/IL2-SR-CommonTests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.3")]
-[assembly: AssemblyFileVersion("1.0.1.3")]
+[assembly: AssemblyVersion("1.0.1.4")]
+[assembly: AssemblyFileVersion("1.0.1.4")]

--- a/IL2-SR-CommonTests/Properties/AssemblyInfo.cs
+++ b/IL2-SR-CommonTests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.4")]
-[assembly: AssemblyFileVersion("1.0.1.4")]
+[assembly: AssemblyVersion("1.0.1.5")]
+[assembly: AssemblyFileVersion("1.0.1.5")]

--- a/IL2-SimpleRadio Server/Properties/AssemblyInfo.cs
+++ b/IL2-SimpleRadio Server/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.4")]
-[assembly: AssemblyFileVersion("1.0.1.4")]
+[assembly: AssemblyVersion("1.0.1.5")]
+[assembly: AssemblyFileVersion("1.0.1.5")]

--- a/IL2-SimpleRadio Server/Properties/AssemblyInfo.cs
+++ b/IL2-SimpleRadio Server/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.3")]
-[assembly: AssemblyFileVersion("1.0.1.3")]
+[assembly: AssemblyVersion("1.0.1.4")]
+[assembly: AssemblyFileVersion("1.0.1.4")]

--- a/IL2-SimpleRadio Server/app.manifest
+++ b/IL2-SimpleRadio Server/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.1.4" name="MyApplication.app"/>
+  <assemblyIdentity version="1.0.1.5" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/IL2-SimpleRadio Server/app.manifest
+++ b/IL2-SimpleRadio Server/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.1.3" name="MyApplication.app"/>
+  <assemblyIdentity version="1.0.1.4" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/Installer/Properties/AssemblyInfo.cs
+++ b/Installer/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.4")]
-[assembly: AssemblyFileVersion("1.0.1.4")]
+[assembly: AssemblyVersion("1.0.1.5")]
+[assembly: AssemblyFileVersion("1.0.1.5")]

--- a/Installer/Properties/AssemblyInfo.cs
+++ b/Installer/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.3")]
-[assembly: AssemblyFileVersion("1.0.1.3")]
+[assembly: AssemblyVersion("1.0.1.4")]
+[assembly: AssemblyFileVersion("1.0.1.4")]

--- a/Installer/Properties/app.manifest
+++ b/Installer/Properties/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.1.4" name="MyApplication.app"/>
+  <assemblyIdentity version="1.0.1.5" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/Installer/Properties/app.manifest
+++ b/Installer/Properties/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.1.3" name="MyApplication.app"/>
+  <assemblyIdentity version="1.0.1.4" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">


### PR DESCRIPTION
Our flight sim group Flying Tin Cans (FTC) is looking at moving to SRS for our weekly campaigns. Our radar system utilizes the WW1 factions, but we need them to be in the same red/blue radios in order to function as ground control. I figured modifying the incoming telemetry data from IL-2 would be the simplest way to implement this change. In file IL2-SR-Client/Network/IL2/IL2RadioSyncHandler.cs.

If you don't want to add this change to the main release, I will probably just implement it server side instead and run a custom version on our server so our pilots don't need to all run a custom client. Also don't think it makes sense to have two different releases out in the wild (haven't quite looked at the release pipeline as well).

I also rev-ed the solution if that would be helpful for pulling in and releasing. If I missed something or did it wrong feel free to only accept the first commit :).