### PR TITLE
Adding Channel Hotkey binds 6 through 12

### DIFF
--- a/IL2-SR-Client/Input/InputDeviceManager.cs
+++ b/IL2-SR-Client/Input/InputDeviceManager.cs
@@ -654,6 +654,16 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.Settings
                                                 RadioHelper.SelectRadioChannel(5, ClientStateSingleton.Instance.PlayerGameState.selected);
                                             }
                                             break;
+                                        case InputBinding.RadioChannel6:
+                                            if (!RadioHelper.IsSecondRadioAvailable())
+                                            {
+                                                RadioHelper.SelectRadioChannel(6, 1);
+                                            }
+                                            else
+                                            {
+                                                RadioHelper.SelectRadioChannel(6, ClientStateSingleton.Instance.PlayerGameState.selected);
+                                            }
+                                            break;
                                         case InputBinding.PreviousRadio:
                                             RadioHelper.PreviousRadio();
                                             break;

--- a/IL2-SR-Client/Input/InputDeviceManager.cs
+++ b/IL2-SR-Client/Input/InputDeviceManager.cs
@@ -664,6 +664,66 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.Settings
                                                 RadioHelper.SelectRadioChannel(6, ClientStateSingleton.Instance.PlayerGameState.selected);
                                             }
                                             break;
+                                        case InputBinding.RadioChannel7:
+                                            if (!RadioHelper.IsSecondRadioAvailable())
+                                            {
+                                                RadioHelper.SelectRadioChannel(7, 1);
+                                            }
+                                            else
+                                            {
+                                                RadioHelper.SelectRadioChannel(7, ClientStateSingleton.Instance.PlayerGameState.selected);
+                                            }
+                                            break;
+                                        case InputBinding.RadioChannel8:
+                                            if (!RadioHelper.IsSecondRadioAvailable())
+                                            {
+                                                RadioHelper.SelectRadioChannel(8, 1);
+                                            }
+                                            else
+                                            {
+                                                RadioHelper.SelectRadioChannel(8, ClientStateSingleton.Instance.PlayerGameState.selected);
+                                            }
+                                            break;
+                                        case InputBinding.RadioChannel9:
+                                            if (!RadioHelper.IsSecondRadioAvailable())
+                                            {
+                                                RadioHelper.SelectRadioChannel(9, 1);
+                                            }
+                                            else
+                                            {
+                                                RadioHelper.SelectRadioChannel(9, ClientStateSingleton.Instance.PlayerGameState.selected);
+                                            }
+                                            break;
+                                        case InputBinding.RadioChannel10:
+                                            if (!RadioHelper.IsSecondRadioAvailable())
+                                            {
+                                                RadioHelper.SelectRadioChannel(10, 1);
+                                            }
+                                            else
+                                            {
+                                                RadioHelper.SelectRadioChannel(10, ClientStateSingleton.Instance.PlayerGameState.selected);
+                                            }
+                                            break;
+                                        case InputBinding.RadioChannel11:
+                                            if (!RadioHelper.IsSecondRadioAvailable())
+                                            {
+                                                RadioHelper.SelectRadioChannel(11, 1);
+                                            }
+                                            else
+                                            {
+                                                RadioHelper.SelectRadioChannel(11, ClientStateSingleton.Instance.PlayerGameState.selected);
+                                            }
+                                            break;
+                                        case InputBinding.RadioChannel12:
+                                            if (!RadioHelper.IsSecondRadioAvailable())
+                                            {
+                                                RadioHelper.SelectRadioChannel(12, 1);
+                                            }
+                                            else
+                                            {
+                                                RadioHelper.SelectRadioChannel(12, ClientStateSingleton.Instance.PlayerGameState.selected);
+                                            }
+                                            break;
                                         case InputBinding.PreviousRadio:
                                             RadioHelper.PreviousRadio();
                                             break;

--- a/IL2-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/IL2-SR-Client/Settings/GlobalSettingsStore.cs
@@ -168,6 +168,9 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.Settings
         RadioChannelDown = 132,
         ModifierRadioChannelDown = 232,
 
+        RadioChannel6 = 133,
+        ModifierRadioChannel6 = 233,
+
     }
 
 

--- a/IL2-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/IL2-SR-Client/Settings/GlobalSettingsStore.cs
@@ -126,26 +126,26 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.Settings
         RadioChannel5 = 117,
         ModifierRadioChannel5 = 217,
 
-        Up0001 = 118,
-        ModifierUp0001 = 218,
+        RadioChannel6 = 118,
+        ModifierRadioChannel6 = 218,
 
-        Down100 = 119,
-        ModifierDown100 = 219,
+        RadioChannel7 = 119,
+        ModifierRadioChannel7 = 219,
 
-        Down10 = 120,
-        ModifierDown10 = 220,
+        RadioChannel8 = 120,
+        ModifierRadioChannel8 = 220,
 
-        Down1 = 121,
-        ModifierDown1 = 221,
+        RadioChannel9 = 121,
+        ModifierRadioChannel9 = 221,
 
-        Down01 = 122,
-        ModifierDown01 = 222,
+        RadioChannel10 = 122,
+        ModifierRadioChannel10 = 222,
 
-        Down001 = 123,
-        ModifierDown001 = 223,
+        RadioChannel11 = 123,
+        ModifierRadioChannel11 = 223,
 
-        Down0001 = 124,
-        ModifierDown0001 = 224,
+        RadioChannel12 = 124,
+        ModifierRadioChannel12 = 224,
 
         NextRadio = 125,
         ModifierNextRadio = 225,
@@ -167,9 +167,6 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.Settings
 
         RadioChannelDown = 132,
         ModifierRadioChannelDown = 232,
-
-        RadioChannel6 = 133,
-        ModifierRadioChannel6 = 233,
 
     }
 

--- a/IL2-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/IL2-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -393,20 +393,56 @@
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioChannel6}"
                                                        InputName="Radio Channel 6" />
 
-                            <local:InputBindingControl x:Name="NextRadio"
+                            <local:InputBindingControl x:Name="RadioChannel7"
                                                        Grid.Row="14"
+                                                       Grid.ColumnSpan="5"
+                                                       ControlInputBinding="{x:Static settings:InputBinding.RadioChannel7}"
+                                                       InputName="Radio Channel 7" />
+
+                            <local:InputBindingControl x:Name="RadioChannel8"
+                                                       Grid.Row="15"
+                                                       Grid.ColumnSpan="5"
+                                                       ControlInputBinding="{x:Static settings:InputBinding.RadioChannel8}"
+                                                       InputName="Radio Channel 8" />
+
+                            <local:InputBindingControl x:Name="RadioChannel9"
+                                                       Grid.Row="16"
+                                                       Grid.ColumnSpan="5"
+                                                       ControlInputBinding="{x:Static settings:InputBinding.RadioChannel9}"
+                                                       InputName="Radio Channel 9" />
+
+                            <local:InputBindingControl x:Name="RadioChannel10"
+                                                       Grid.Row="17"
+                                                       Grid.ColumnSpan="5"
+                                                       ControlInputBinding="{x:Static settings:InputBinding.RadioChannel10}"
+                                                       InputName="Radio Channel 10" />
+
+                            <local:InputBindingControl x:Name="RadioChannel11"
+                                                       Grid.Row="18"
+                                                       Grid.ColumnSpan="5"
+                                                       ControlInputBinding="{x:Static settings:InputBinding.RadioChannel11}"
+                                                       InputName="Radio Channel 11" />
+
+                            <local:InputBindingControl x:Name="RadioChannel12"
+                                                       Grid.Row="19"
+                                                       Grid.ColumnSpan="5"
+                                                       ControlInputBinding="{x:Static settings:InputBinding.RadioChannel12}"
+                                                       InputName="Radio Channel 12" />
+
+                            <local:InputBindingControl x:Name="NextRadio"
+                                                       Grid.Row="20"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.NextRadio}"
                                                        InputName="Select Next Radio" />
 
                             <local:InputBindingControl x:Name="PreviousRadio"
-                                                       Grid.Row="15"
+                                                       Grid.Row="21"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.PreviousRadio}"
                                                        InputName="Select Previous Radio" />
 
                             <local:InputBindingControl x:Name="ReadStatus"
-                                                       Grid.Row="16"
+                                                       Grid.Row="22"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.ReadStatus}"
                                                        InputName="Read Status (TTS on required)" />

--- a/IL2-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/IL2-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -305,6 +305,8 @@
                                 <RowDefinition />
                                 <RowDefinition />
                                 <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
                             </Grid.RowDefinitions>
 
                             <Label x:Name="DeviceLabel"
@@ -385,20 +387,26 @@
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioChannel5}"
                                                        InputName="Radio Channel 5" />
 
-                            <local:InputBindingControl x:Name="NextRadio"
+                            <local:InputBindingControl x:Name="RadioChannel6"
                                                        Grid.Row="13"
+                                                       Grid.ColumnSpan="5"
+                                                       ControlInputBinding="{x:Static settings:InputBinding.RadioChannel6}"
+                                                       InputName="Radio Channel 6" />
+
+                            <local:InputBindingControl x:Name="NextRadio"
+                                                       Grid.Row="14"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.NextRadio}"
                                                        InputName="Select Next Radio" />
 
                             <local:InputBindingControl x:Name="PreviousRadio"
-                                                       Grid.Row="14"
+                                                       Grid.Row="15"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.PreviousRadio}"
                                                        InputName="Select Previous Radio" />
 
                             <local:InputBindingControl x:Name="ReadStatus"
-                                                       Grid.Row="15"
+                                                       Grid.Row="16"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.ReadStatus}"
                                                        InputName="Read Status (TTS on required)" />

--- a/IL2-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/IL2-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -381,6 +381,10 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.UI
             RadioChannel5.ControlInputBinding = InputBinding.RadioChannel5;
             RadioChannel5.InputDeviceManager = InputManager;
 
+            RadioChannel6.InputName = "Radio Channel 6";
+            RadioChannel6.ControlInputBinding = InputBinding.RadioChannel6;
+            RadioChannel6.InputDeviceManager = InputManager;
+
             NextRadio.InputName = "Select Next Radio / Intercom";
             NextRadio.ControlInputBinding = InputBinding.NextRadio;
             NextRadio.InputDeviceManager = InputManager;
@@ -414,6 +418,7 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.UI
             RadioChannel3.LoadInputSettings();
             RadioChannel4.LoadInputSettings();
             RadioChannel5.LoadInputSettings();
+            RadioChannel6.LoadInputSettings();
             NextRadio.LoadInputSettings();
             PreviousRadio.LoadInputSettings();
             ReadStatus.LoadInputSettings();

--- a/IL2-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/IL2-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -385,6 +385,30 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.UI
             RadioChannel6.ControlInputBinding = InputBinding.RadioChannel6;
             RadioChannel6.InputDeviceManager = InputManager;
 
+            RadioChannel7.InputName = "Radio Channel 7";
+            RadioChannel7.ControlInputBinding = InputBinding.RadioChannel7;
+            RadioChannel7.InputDeviceManager = InputManager;
+
+            RadioChannel8.InputName = "Radio Channel 8";
+            RadioChannel8.ControlInputBinding = InputBinding.RadioChannel8;
+            RadioChannel8.InputDeviceManager = InputManager;
+
+            RadioChannel9.InputName = "Radio Channel 9";
+            RadioChannel9.ControlInputBinding = InputBinding.RadioChannel9;
+            RadioChannel9.InputDeviceManager = InputManager;
+
+            RadioChannel10.InputName = "Radio Channel 10";
+            RadioChannel10.ControlInputBinding = InputBinding.RadioChannel10;
+            RadioChannel10.InputDeviceManager = InputManager;
+
+            RadioChannel11.InputName = "Radio Channel 11";
+            RadioChannel11.ControlInputBinding = InputBinding.RadioChannel11;
+            RadioChannel11.InputDeviceManager = InputManager;
+
+            RadioChannel12.InputName = "Radio Channel 12";
+            RadioChannel12.ControlInputBinding = InputBinding.RadioChannel12;
+            RadioChannel12.InputDeviceManager = InputManager;
+
             NextRadio.InputName = "Select Next Radio / Intercom";
             NextRadio.ControlInputBinding = InputBinding.NextRadio;
             NextRadio.InputDeviceManager = InputManager;
@@ -419,6 +443,12 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.UI
             RadioChannel4.LoadInputSettings();
             RadioChannel5.LoadInputSettings();
             RadioChannel6.LoadInputSettings();
+            RadioChannel7.LoadInputSettings();
+            RadioChannel8.LoadInputSettings();
+            RadioChannel9.LoadInputSettings();
+            RadioChannel10.LoadInputSettings();
+            RadioChannel11.LoadInputSettings();
+            RadioChannel12.LoadInputSettings();
             NextRadio.LoadInputSettings();
             PreviousRadio.LoadInputSettings();
             ReadStatus.LoadInputSettings();


### PR DESCRIPTION
In this change added associated enums and UI elements to make binds work for radio channels 6 through 12

Removed deprecated binds Up0001, Down100, Down100, Down1, Down01, Down001, and Down0001 in order to add these binds.